### PR TITLE
Prevents registering duplicate event listeners

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -70,10 +70,13 @@ Cache.prototype.getCustom = function(key, customGetter, ttl, callback){
 		}
 		//No cached response - use getter to set new cache item
 		else{
-			emitter.once('requestCompleted'+key,function(cb){ return function(data){
+			var eventNames = emitter.eventNames();
+			if(eventNames.indexOf('requestCompleted'+key) === -1){
+				emitter.once('requestCompleted'+key,function(cb){ return function(data){
 					delete _cache.requestQueued[key];
 					return cb(data);
-			}}(callback))
+				}}(callback))
+			}
 
 			//Start getter if it hasn't been started
 			if(typeof _cache.requestQueued[key] === 'undefined'){

--- a/cache.js
+++ b/cache.js
@@ -71,7 +71,7 @@ Cache.prototype.getCustom = function(key, customGetter, ttl, callback){
 		//No cached response - use getter to set new cache item
 		else{
 			var eventNames = emitter.eventNames();
-			if(eventNames.indexOf('requestCompleted'+key) === -1){
+			if(eventNames.indexOf('requestCompleted'+key) === -1){ // Prevents registering duplicate listeners before request completes
 				emitter.once('requestCompleted'+key,function(cb){ return function(data){
 					delete _cache.requestQueued[key];
 					return cb(data);


### PR DESCRIPTION
Duplicate event listeners would be registered if additional requests happened before the mongo request completed.

Prevents warning: "MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 requestCompleted... listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit"